### PR TITLE
Automate Signet environment setup

### DIFF
--- a/SIGNET_SETUP.md
+++ b/SIGNET_SETUP.md
@@ -90,6 +90,8 @@ Several helper scripts have been created to simplify working with the Signet env
 
 - `scripts/bitcoin-cli-signet.sh`: Run bitcoin-cli commands with the correct configuration
 - `scripts/request-signet-coins.sh`: Request test coins from a Signet faucet
+- `scripts/setup-signet-environment.sh`: Start Bitcoin Core, create the test wallet, launch Ord, and request coins automatically
+- `scripts/teardown-signet-environment.sh`: Stop all Signet services
 
 ## Configuration
 

--- a/docs/signet-environment-setup.md
+++ b/docs/signet-environment-setup.md
@@ -51,6 +51,8 @@ Several helper scripts have been created to simplify testing:
 - `scripts/bitcoin-cli-signet.sh` - For running Bitcoin CLI commands with the correct configuration
 - `scripts/request-signet-coins.sh` - For requesting test coins from a Signet faucet
 - `scripts/test-verifiable-credential.js` - For verifying the environment and testing credential creation
+- `scripts/setup-signet-environment.sh` - Launches Bitcoin Core and Ord, creates the test wallet, and requests faucet funds
+- `scripts/teardown-signet-environment.sh` - Stops the Signet environment services
 
 ### 5. Configuration Files
 
@@ -62,16 +64,19 @@ All configuration settings are stored in:
 ## Usage Instructions
 
 ### Starting the Environment
+You can start all required services with a single command:
 
-1. Start Bitcoin Core:
-   ```
-   npm run btc:signet
-   ```
+```bash
+./scripts/setup-signet-environment.sh
+```
 
-2. Start the Ord server:
-   ```
-   npm run ord:server
-   ```
+This script launches Bitcoin Core, creates the test wallet, starts the Ord indexer and server, and requests faucet funds automatically.
+
+Stop all services with:
+
+```bash
+./scripts/teardown-signet-environment.sh
+```
 
 ### Testing the Environment
 

--- a/scripts/setup-signet-environment.sh
+++ b/scripts/setup-signet-environment.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple automation script to start the local Signet testing environment
+# Requires bitcoind and ord binaries installed and accessible in PATH.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+CONFIG_FILE="$ROOT_DIR/signet-config.json"
+
+# Helper function to extract values from signet-config.json using node
+json() {
+  node -e "console.log(require('$CONFIG_FILE')$1)" 2>/dev/null
+}
+
+BITCOIN_CONF=$(json '.bitcoin.configFile')
+BITCOIN_CLI=$(json '.scripts.bitcoinCli')
+RPC_URL=$(json '.bitcoin.rpcUrl')
+COOKIE_FILE=$(json '.bitcoin.cookieFile')
+ORD_DATA_DIR=$(json '.ord.dataDir')
+WALLET_NAME=$(json '.wallet.name')
+ADDRESS=$(json '.wallet.addresses.verifiable_credential')
+REQUEST_COINS=$(json '.scripts.requestCoins')
+
+echo "Starting bitcoind on Signet..."
+bitcoind -conf="$BITCOIN_CONF" -daemon
+
+# Give bitcoind a moment to start
+sleep 3
+
+# Create wallet if it doesn't exist
+if ! $BITCOIN_CLI -rpcwallet="$WALLET_NAME" getwalletinfo >/dev/null 2>&1; then
+  echo "Creating wallet $WALLET_NAME"
+  $BITCOIN_CLI createwallet "$WALLET_NAME"
+fi
+
+# Generate an address to ensure the wallet is initialized
+$BITCOIN_CLI -rpcwallet="$WALLET_NAME" getnewaddress "verifiable_credential" "bech32" >/dev/null
+
+echo "Launching Ord indexer and server..."
+ORD_ARGS=(--signet --bitcoin-rpc-url="$RPC_URL" --cookie-file="$COOKIE_FILE" --data-dir="$ORD_DATA_DIR")
+ord "${ORD_ARGS[@]}" index &
+ORD_INDEX_PID=$!
+ord "${ORD_ARGS[@]}" server &
+ORD_SERVER_PID=$!
+
+# Request test coins
+echo "Requesting Signet coins from faucet..."
+$REQUEST_COINS "$ADDRESS" || true
+
+cat <<MSG
+Signet environment started.
+- bitcoind running with config $BITCOIN_CONF
+- Ord indexer PID: $ORD_INDEX_PID
+- Ord server PID: $ORD_SERVER_PID
+MSG

--- a/scripts/teardown-signet-environment.sh
+++ b/scripts/teardown-signet-environment.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stop running Signet services started by setup-signet-environment.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+CONFIG_FILE="$ROOT_DIR/signet-config.json"
+
+json() {
+  node -e "console.log(require('$CONFIG_FILE')$1)" 2>/dev/null
+}
+
+BITCOIN_CLI=$(json '.scripts.bitcoinCli')
+
+# Try to stop ord processes
+if pgrep -f "ord.*--signet" >/dev/null; then
+  echo "Stopping Ord processes..."
+  pkill -f "ord.*--signet" || true
+fi
+
+# Stop bitcoind
+if pgrep -f "bitcoind" >/dev/null; then
+  echo "Stopping bitcoind..."
+  $BITCOIN_CLI stop || true
+fi
+
+echo "Signet environment stopped."

--- a/signet-config.json
+++ b/signet-config.json
@@ -1,13 +1,13 @@
 {
   "network": "signet",
   "bitcoin": {
-    "dataDir": "/Users/brian/Projects/ordinalsplus/data",
-    "configFile": "/Users/brian/Projects/ordinalsplus/bitcoin.conf",
+    "dataDir": "./data",
+    "configFile": "./bitcoin.conf",
     "rpcUrl": "http://127.0.0.1:38332",
-    "cookieFile": "/Users/brian/Projects/ordinalsplus/data/signet/.cookie"
+    "cookieFile": "./data/signet/.cookie"
   },
   "ord": {
-    "dataDir": "/Users/brian/Projects/ordinalsplus/data/signet",
+    "dataDir": "./data/signet",
     "indexSats": true
   },
   "wallet": {


### PR DESCRIPTION
## Summary
- add setup and teardown scripts for Signet testing
- use relative paths in `signet-config.json`
- document scripts in Signet setup guides

## Testing
- `npm run test:all` *(fails: Network request failed, jest.runAllTimers is not a function)*