### PR TITLE
Automate Signet environment setup

### DIFF
--- a/SIGNET_SETUP.md
+++ b/SIGNET_SETUP.md
@@ -30,13 +30,13 @@ signet=1
 # Enable RPC server
 server=1
 rpcallowip=127.0.0.1
-cookiefile=/Users/brian/Projects/ordinalsplus/data/signet/.cookie
+cookiefile=./data/signet/.cookie
 
 # Transaction index (required by ord)
 txindex=1
 
 # Data directory
-datadir=/Users/brian/Projects/ordinalsplus/data
+datadir=./data
 ```
 
 ### 2. Starting Bitcoin Core on Signet
@@ -90,6 +90,8 @@ Several helper scripts have been created to simplify working with the Signet env
 
 - `scripts/bitcoin-cli-signet.sh`: Run bitcoin-cli commands with the correct configuration
 - `scripts/request-signet-coins.sh`: Request test coins from a Signet faucet
+- `scripts/setup-signet-environment.sh`: Start Bitcoin Core, create the test wallet, launch Ord, and request coins automatically
+- `scripts/teardown-signet-environment.sh`: Stop all Signet services
 
 ## Configuration
 

--- a/bitcoin.conf
+++ b/bitcoin.conf
@@ -6,7 +6,7 @@ signet=1
 # Enable RPC server
 server=1
 rpcallowip=127.0.0.1
-cookiefile=/Users/brian/Projects/ordinalsplus/data/signet/.cookie
+cookiefile=./data/signet/.cookie
 
 # Transaction index (required by ord)
 txindex=1
@@ -15,4 +15,4 @@ txindex=1
 # prune=550 # Minimum prune target in MiB
 
 # Optional: Set data directory
-datadir=/Users/brian/Projects/ordinalsplus/data
+datadir=./data

--- a/docs/signet-environment-setup.md
+++ b/docs/signet-environment-setup.md
@@ -20,11 +20,11 @@ The Signet testing environment consists of the following components:
 Bitcoin Core has been configured to run on Signet with the following settings:
 
 - Network: Signet
-- Data directory: `/Users/brian/Projects/ordinalsplus/data`
+- Data directory: `./data`
 - Transaction indexing enabled (required for Ord)
 - RPC server enabled on localhost
 
-The configuration is stored in `/Users/brian/Projects/ordinalsplus/bitcoin.conf`.
+The configuration is stored in `./bitcoin.conf`.
 
 ### 2. Wallet Setup
 
@@ -33,7 +33,7 @@ A dedicated wallet has been created for Verifiable credential testing:
 - Wallet name: `verifiable_credential_wallet`
 - Address for Verifiable credential: `tb1qlm0ztddtrfu6temuf5ncpssrkaqgtx0wmgdn63`
 
-The wallet information is documented in `/Users/brian/Projects/ordinalsplus/verifiable-credential-wallet-info.md`.
+The wallet information is documented in `./verifiable-credential-wallet-info.md`.
 
 ### 3. Ord Server Configuration
 
@@ -41,7 +41,7 @@ The Ord server has been configured to:
 
 - Connect to the Bitcoin Core node on Signet
 - Use the same cookie file for authentication
-- Store index data in `/Users/brian/Projects/ordinalsplus/data/signet`
+- Store index data in `./data/signet`
 - Serve the web interface on port 80
 
 ### 4. Helper Scripts
@@ -51,6 +51,8 @@ Several helper scripts have been created to simplify testing:
 - `scripts/bitcoin-cli-signet.sh` - For running Bitcoin CLI commands with the correct configuration
 - `scripts/request-signet-coins.sh` - For requesting test coins from a Signet faucet
 - `scripts/test-verifiable-credential.js` - For verifying the environment and testing credential creation
+- `scripts/setup-signet-environment.sh` - Launches Bitcoin Core and Ord, creates the test wallet, and requests faucet funds
+- `scripts/teardown-signet-environment.sh` - Stops the Signet environment services
 
 ### 5. Configuration Files
 
@@ -62,16 +64,19 @@ All configuration settings are stored in:
 ## Usage Instructions
 
 ### Starting the Environment
+You can start all required services with a single command:
 
-1. Start Bitcoin Core:
-   ```
-   npm run btc:signet
-   ```
+```bash
+./scripts/setup-signet-environment.sh
+```
 
-2. Start the Ord server:
-   ```
-   npm run ord:server
-   ```
+This script launches Bitcoin Core, creates the test wallet, starts the Ord indexer and server, and requests faucet funds automatically.
+
+Stop all services with:
+
+```bash
+./scripts/teardown-signet-environment.sh
+```
 
 ### Testing the Environment
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "scripts": {
-    "btc:signet": "bitcoind -conf=/Users/brian/Projects/ordinalsplus/bitcoin.conf",
-    "ord:index": "ord -s --bitcoin-rpc-url=http://127.0.0.1:38332 --cookie-file=/Users/brian/Projects/ordinalsplus/data/signet/.cookie --data-dir=/Users/brian/Projects/ordinalsplus/data/signet index run",
-    "ord:server": "ord -s --bitcoin-rpc-url=http://127.0.0.1:38332 --cookie-file=/Users/brian/Projects/ordinalsplus/data/signet/.cookie --data-dir=/Users/brian/Projects/ordinalsplus/data/signet server",
+    "btc:signet": "bitcoind -conf=./bitcoin.conf",
+    "ord:index": "ord -s --bitcoin-rpc-url=http://127.0.0.1:38332 --cookie-file=./data/signet/.cookie --data-dir=./data/signet index run",
+    "ord:server": "ord -s --bitcoin-rpc-url=http://127.0.0.1:38332 --cookie-file=./data/signet/.cookie --data-dir=./data/signet server",
     "test": "npm run test:all",
     "test:all": "echo '\n📦 Testing all packages\n' && npm run test:summary:ordinalsplus && npm run test:summary:api && npm run test:summary:explorer && echo '\n✅ All tests completed successfully!\n'",
     "test:summary:ordinalsplus": "echo '\n📋 Testing ordinalsplus package...' && cd packages/ordinalsplus && (bun test > /tmp/test-output.txt 2>&1 || (cat /tmp/test-output.txt && exit 1)) && grep -E 'pass|fail|skip|test|Test|PASS|FAIL|SKIP' /tmp/test-output.txt | grep -v 'node_modules' | tail -n 10",

--- a/scripts/bitcoin-cli-signet.sh
+++ b/scripts/bitcoin-cli-signet.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Helper script to run bitcoin-cli with the correct configuration for Signet
-bitcoin-cli -conf=/Users/brian/Projects/ordinalsplus/bitcoin.conf -signet "$@"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+bitcoin-cli -conf="${ROOT_DIR}/bitcoin.conf" -signet "$@"

--- a/scripts/ord-wallet-signet.sh
+++ b/scripts/ord-wallet-signet.sh
@@ -1,4 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Helper script to run ord wallet commands with the correct configuration for the verifiable credential wallet
-ord -s --bitcoin-rpc-url=http://127.0.0.1:38332 --cookie-file=/Users/brian/Projects/ordinalsplus/data/signet/.cookie --data-dir=/Users/brian/Projects/ordinalsplus/data/signet/verifiable_credential_wallet wallet "$@"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+COOKIE_FILE="${ROOT_DIR}/data/signet/.cookie"
+WALLET_DIR="${ROOT_DIR}/data/signet/verifiable_credential_wallet"
+ord -s --bitcoin-rpc-url=http://127.0.0.1:38332 --cookie-file="$COOKIE_FILE" --data-dir="$WALLET_DIR" wallet "$@"

--- a/scripts/setup-signet-environment.sh
+++ b/scripts/setup-signet-environment.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple automation script to start the local Signet testing environment
+# Requires bitcoind and ord binaries installed and accessible in PATH.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+CONFIG_FILE="$ROOT_DIR/signet-config.json"
+
+# Helper function to extract values from signet-config.json using node
+json() {
+  node -e "console.log(require('$CONFIG_FILE')$1)" 2>/dev/null
+}
+
+BITCOIN_CONF_REL=$(json '.bitcoin.configFile')
+BITCOIN_CONF="$(realpath "$ROOT_DIR/$BITCOIN_CONF_REL")"
+BITCOIN_CLI_REL=$(json '.scripts.bitcoinCli')
+BITCOIN_CLI="$(realpath "$ROOT_DIR/$BITCOIN_CLI_REL")"
+RPC_URL=$(json '.bitcoin.rpcUrl')
+COOKIE_FILE="$(realpath "$ROOT_DIR/$(json '.bitcoin.cookieFile')")"
+ORD_DATA_DIR="$(realpath "$ROOT_DIR/$(json '.ord.dataDir')")"
+WALLET_NAME=$(json '.wallet.name')
+ADDRESS=$(json '.wallet.addresses.verifiable_credential')
+REQUEST_COINS_REL=$(json '.scripts.requestCoins')
+REQUEST_COINS="$(realpath "$ROOT_DIR/$REQUEST_COINS_REL")"
+
+echo "Starting bitcoind on Signet..."
+bitcoind -conf="$BITCOIN_CONF" -daemon
+
+# Give bitcoind a moment to start
+sleep 3
+
+# Create wallet if it doesn't exist
+if ! $BITCOIN_CLI -rpcwallet="$WALLET_NAME" getwalletinfo >/dev/null 2>&1; then
+  echo "Creating wallet $WALLET_NAME"
+  $BITCOIN_CLI createwallet "$WALLET_NAME"
+fi
+
+# Generate an address to ensure the wallet is initialized
+$BITCOIN_CLI -rpcwallet="$WALLET_NAME" getnewaddress "verifiable_credential" "bech32" >/dev/null
+
+echo "Launching Ord indexer and server..."
+ORD_ARGS=(--signet --bitcoin-rpc-url="$RPC_URL" --cookie-file="$COOKIE_FILE" --data-dir="$ORD_DATA_DIR")
+ord "${ORD_ARGS[@]}" index &
+ORD_INDEX_PID=$!
+ord "${ORD_ARGS[@]}" server &
+ORD_SERVER_PID=$!
+
+# Request test coins
+echo "Requesting Signet coins from faucet..."
+$REQUEST_COINS "$ADDRESS" || true
+
+cat <<MSG
+Signet environment started.
+- bitcoind running with config $BITCOIN_CONF
+- Ord indexer PID: $ORD_INDEX_PID
+- Ord server PID: $ORD_SERVER_PID
+MSG

--- a/scripts/teardown-signet-environment.sh
+++ b/scripts/teardown-signet-environment.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stop running Signet services started by setup-signet-environment.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+CONFIG_FILE="$ROOT_DIR/signet-config.json"
+
+json() {
+  node -e "console.log(require('$CONFIG_FILE')$1)" 2>/dev/null
+}
+
+BITCOIN_CLI_REL=$(json '.scripts.bitcoinCli')
+BITCOIN_CLI="$(realpath "$ROOT_DIR/$BITCOIN_CLI_REL")"
+
+# Try to stop ord processes
+if pgrep -f "ord.*--signet" >/dev/null; then
+  echo "Stopping Ord processes..."
+  pkill -f "ord.*--signet" || true
+fi
+
+# Stop bitcoind
+if pgrep -f "bitcoind" >/dev/null; then
+  echo "Stopping bitcoind..."
+  $BITCOIN_CLI stop || true
+fi
+
+echo "Signet environment stopped."

--- a/signet-config.json
+++ b/signet-config.json
@@ -1,13 +1,13 @@
 {
   "network": "signet",
   "bitcoin": {
-    "dataDir": "/Users/brian/Projects/ordinalsplus/data",
-    "configFile": "/Users/brian/Projects/ordinalsplus/bitcoin.conf",
+    "dataDir": "./data",
+    "configFile": "./bitcoin.conf",
     "rpcUrl": "http://127.0.0.1:38332",
-    "cookieFile": "/Users/brian/Projects/ordinalsplus/data/signet/.cookie"
+    "cookieFile": "./data/signet/.cookie"
   },
   "ord": {
-    "dataDir": "/Users/brian/Projects/ordinalsplus/data/signet",
+    "dataDir": "./data/signet",
     "indexSats": true
   },
   "wallet": {

--- a/verifiable-credential-wallet-info.md
+++ b/verifiable-credential-wallet-info.md
@@ -12,7 +12,7 @@
   - **Created**: 2025-05-18
 
 ## Ordinals Wallet Details
-- **Data Directory**: `/Users/brian/Projects/ordinalsplus/data/signet/verifiable_credential_wallet`
+- **Data Directory**: `./data/signet/verifiable_credential_wallet`
 - **Network**: Signet
 - **Purpose**: For inscribing Verifiable credential on Cygnet network
 - **Mnemonic**: `obscure vapor guess virtual awkward plunge text onion gospel seed guess around`


### PR DESCRIPTION
## Summary
- add setup and teardown scripts for Signet testing
- use relative paths in bitcoin.conf and config files
- update helper scripts to resolve repository paths
- document the portable Signet configuration

## Testing
- `npm run test:all` *(fails: many tests fail due to missing network setup)*