### PR TITLE
Fix commit script internal key handling

### DIFF
--- a/packages/ordinalsplus/src/inscription/p2tr/key-utils.ts
+++ b/packages/ordinalsplus/src/inscription/p2tr/key-utils.ts
@@ -33,7 +33,7 @@ export interface P2TRAddressInfo {
   /** The output script for the P2TR address */
   script: Uint8Array;
   /** The internal key used in the P2TR address */
-  internalKey: Uint8Array;
+  internalKey?: Uint8Array;
 }
 
 /**

--- a/packages/ordinalsplus/src/inscription/scripts/ordinal-reveal.ts
+++ b/packages/ordinalsplus/src/inscription/scripts/ordinal-reveal.ts
@@ -191,8 +191,8 @@ export function prepareInscription(params: PrepareInscriptionParams): PreparedIn
   const scriptInfo = extractScriptInfo(scriptTree);
   
   // Generate commit address
-  // Use recovery key if provided, otherwise use reveal key
-  const internalKey = recoveryPublicKey || pubKey;
+  // Use recovery key if provided; otherwise leave internal key undefined
+  const internalKey = recoveryPublicKey;
   
   // Get network object
   const btcNetwork = getScureNetwork(network);
@@ -211,10 +211,9 @@ export function prepareInscription(params: PrepareInscriptionParams): PreparedIn
   }
   
   // Create script from output
-  const script = p2tr.script || btc.OutScript.encode({
-    type: 'tr',
-    pubkey: internalKey
-  });
+  const script = p2tr.script || (internalKey
+    ? btc.OutScript.encode({ type: 'tr', pubkey: internalKey })
+    : new Uint8Array());
   
   return {
     commitAddress: {

--- a/packages/ordinalsplus/src/transactions/reveal-transaction.ts
+++ b/packages/ordinalsplus/src/transactions/reveal-transaction.ts
@@ -152,7 +152,6 @@ export async function createRevealTransaction(params: RevealTransactionParams): 
             'Missing commit address, script, or inscription data in prepared inscription for reveal'
           );
       }
-      const commitScript = preparedInscription.commitAddress.script;
       const commitAddress = preparedInscription.commitAddress.address;
       const inscriptionObject = preparedInscription.inscription;
       const pubKey = preparedInscription.revealPublicKey;
@@ -166,7 +165,6 @@ export async function createRevealTransaction(params: RevealTransactionParams): 
         ORDINAL_CUSTOM_SCRIPTS
       );
 
-      console.log(`[DEBUG-REVEAL-FIX] Using PRE-CALCULATED commit script for witness: ${Buffer.from(commitScript).toString('hex')}`);
       console.log(`[DEBUG-REVEAL-FIX] Expected Commit Address from prep: ${commitAddress}`);
       console.log(`[DEBUG-REVEAL-FIX] Reveal Payment Script (for input): ${revealPayment.script ? Buffer.from(revealPayment.script).toString('hex') : 'undefined'}`);
       // Log the entire revealPayment object to inspect its structure for tapleaf info
@@ -177,9 +175,9 @@ export async function createRevealTransaction(params: RevealTransactionParams): 
         ...revealPayment,
         txid: selectedUTXO.txid,
         index: selectedUTXO.vout,
-        witnessUtxo: { 
-          script: commitScript,
-          amount: inputAmount 
+        witnessUtxo: {
+          script: revealPayment.script,
+          amount: inputAmount
         },
         // Removed incorrect redeemScript property.
         // We need to inspect revealPayment object structure to find where 


### PR DESCRIPTION
## Summary
- allow `P2TRAddressInfo` to omit `internalKey`
- leave `internalKey` undefined when preparing inscriptions without a recovery key
- fallback safely when commit script must be derived from taproot output

## Testing
- `bun test packages/ordinalsplus/tests/unit/transactions/reveal-transaction.test.ts` *(fails: Cannot find module)*
- `npm test` *(fails: 45 tests failed)*
