### PR TITLE
Simplify commit creation in explorer

### DIFF
--- a/packages/ordinals-plus-explorer/src/components/inscription/TransactionStep.tsx
+++ b/packages/ordinals-plus-explorer/src/components/inscription/TransactionStep.tsx
@@ -164,21 +164,21 @@ const TransactionStep: React.FC = () => {
       const safetyBufferFeeRate = inscriptionData.feeRate + 0.1;
       const requiredCommitAmount = BigInt(inscriptionData.requiredCommitAmount);
       
-      const commitResult = await ordinalsplus.prepareCommitTransaction({
+      const commitResult = await ordinalsplus.createSimpleCommitTransaction({
         inscription: {
           commitAddress: {
             address: inscriptionData.commitAddress,
             script: commitScript,
-            internalKey: new Uint8Array(32) // Required field with proper size
+            internalKey: new Uint8Array(32)
           },
           inscription: inscriptionData.inscription,
           revealPublicKey: revealPublicKey,
-        } as any,
-        utxos: utxosForApi,
+          revealPrivateKey: hexToBytes(inscriptionData.revealPrivateKeyHex)
+        },
+        utxo: utxosForApi[0],
         changeAddress: walletAddress,
         feeRate: safetyBufferFeeRate,
-        network: inscriptionData.network,
-        minimumCommitAmount: Number(requiredCommitAmount)
+        network: inscriptionData.network
       });
       
       console.log(`[PrepareAndSignCommit] Commit transaction prepared, fee: ${commitResult.fees.commit} sats`);
@@ -489,35 +489,31 @@ const TransactionStep: React.FC = () => {
       
       // Create the reveal transaction
       console.log('[CreateReveal] Creating reveal transaction with ephemeral key');
-      const revealTx = await ordinalsplus.createRevealTransaction({
-        selectedUTXO: {
+      const revealTx = await ordinalsplus.createSimpleRevealTransaction({
+        utxo: {
           txid: commitTxid,
-          vout: 0, // Assume the first output is the commit output
+          vout: 0,
           value: Number(requiredCommitAmount),
-          script: { 
-            type: 'p2tr',
-            address: inscriptionData.commitAddress 
-          }
+          script: { type: 'p2tr', address: inscriptionData.commitAddress }
         },
         preparedInscription: {
           inscription: inscriptionData.inscription,
           commitAddress: {
             address: inscriptionData.commitAddress,
             script: commitScript,
-            internalKey: new Uint8Array(32) // Required field with proper size
+            internalKey: new Uint8Array(32)
           },
           revealPublicKey: revealPublicKey,
+          revealPrivateKey: revealPrivateKey,
           inscriptionScript: {
             script: inscriptionScript,
             controlBlock: controlBlock,
             leafVersion: inscriptionData.inscriptionScript.leafVersion
-          },
-          revealPrivateKey: revealPrivateKey
+          }
         },
         privateKey: revealPrivateKey,
         feeRate: inscriptionData.feeRate,
         network: scureNetwork,
-        commitTransactionId: commitTxid,
         destinationAddress: walletAddress || ''
       });
       // Extract transaction ID

--- a/packages/ordinalsplus/src/index.ts
+++ b/packages/ordinalsplus/src/index.ts
@@ -74,16 +74,20 @@ export {
     prepareResourceInscription, 
     validateResourceCreationParams,
     prepareCommitTransaction,
+    createSimpleCommitTransaction,
     createRevealTransaction,
+    createSimpleRevealTransaction,
     transactionTracker
 } from './transactions';
 
-export type { 
+export type {
     PreparedResourceInfo,
     CommitTransactionParams,
     CommitTransactionResult,
     RevealTransactionParams,
-    RevealTransactionResult
+    RevealTransactionResult,
+    SimpleCommitParams,
+    SimpleRevealParams
 } from './transactions';
 
 // --- Transaction Status Tracking Exports ---

--- a/packages/ordinalsplus/src/transactions/index.ts
+++ b/packages/ordinalsplus/src/transactions/index.ts
@@ -8,6 +8,7 @@ export * from './transaction-status-tracker';
 export * from './transaction-signing';
 export * from './transaction-broadcasting';
 export * from './transaction-confirmation';
+export * from './simple';
 
 // Export other relevant transaction functions here if created, e.g.:
 // export * from './utxo-management'; 

--- a/packages/ordinalsplus/src/transactions/simple.ts
+++ b/packages/ordinalsplus/src/transactions/simple.ts
@@ -1,0 +1,127 @@
+import * as btc from '@scure/btc-signer';
+import * as ordinals from 'micro-ordinals';
+import { base64, hex } from '@scure/base';
+import { PreparedInscription } from '../inscription/scripts/ordinal-reveal';
+import { Utxo, BitcoinNetwork } from '../types';
+import { calculateFee } from './fee-calculation';
+import { getScureNetwork } from '../utils/networks';
+import { CommitTransactionResult } from './commit-transaction';
+import { RevealTransactionResult } from './reveal-transaction';
+
+const MIN_DUST_LIMIT = 546;
+const POSTAGE_VALUE = 551n;
+
+export interface SimpleCommitParams {
+  inscription: PreparedInscription;
+  utxo: Utxo;
+  changeAddress: string;
+  feeRate: number;
+  network?: BitcoinNetwork;
+}
+
+export async function createSimpleCommitTransaction(params: SimpleCommitParams): Promise<CommitTransactionResult> {
+  const { inscription, utxo, changeAddress, feeRate, network = 'mainnet' } = params;
+  const net = getScureNetwork(network);
+
+  const tx = new btc.Transaction();
+  if (!utxo.scriptPubKey) {
+    throw new Error('UTXO missing scriptPubKey');
+  }
+  tx.addInput({
+    txid: utxo.txid,
+    index: utxo.vout,
+    witnessUtxo: {
+      script: Buffer.from(utxo.scriptPubKey, 'hex'),
+      amount: BigInt(utxo.value)
+    }
+  });
+
+  const commitValue = MIN_DUST_LIMIT;
+  const estimatedSize = 68 + 43 + 31 + 10; // rough vbytes for 1 input 2 outputs
+  const fee = Number(calculateFee(estimatedSize, feeRate));
+
+  if (utxo.value < commitValue + fee) {
+    throw new Error('UTXO value too low for commit transaction');
+  }
+
+  tx.addOutputAddress(inscription.commitAddress.address, BigInt(commitValue), net);
+  const change = utxo.value - commitValue - fee;
+  if (change > 0) {
+    tx.addOutputAddress(changeAddress, BigInt(change), net);
+  }
+
+  const psbt = tx.toPSBT();
+  const psbt64 = typeof psbt === 'string' ? psbt : Buffer.from(psbt).toString('base64');
+
+  return {
+    commitAddress: inscription.commitAddress.address,
+    commitPsbtBase64: psbt64,
+    commitPsbt: tx,
+    requiredCommitAmount: commitValue,
+    selectedUtxos: [utxo],
+    fees: { commit: fee },
+  };
+}
+
+export interface SimpleRevealParams {
+  utxo: Utxo;
+  preparedInscription: PreparedInscription;
+  feeRate: number;
+  privateKey?: Uint8Array;
+  network?: BitcoinNetwork;
+  destinationAddress?: string;
+}
+
+export async function createSimpleRevealTransaction(params: SimpleRevealParams): Promise<RevealTransactionResult> {
+  const { utxo, preparedInscription, feeRate, privateKey, network = 'mainnet', destinationAddress } = params;
+  const net = getScureNetwork(network);
+  const customScripts = [ordinals.OutOrdinalReveal];
+  const revealPayment = btc.p2tr(undefined as any, ordinals.p2tr_ord_reveal(preparedInscription.revealPublicKey, [preparedInscription.inscription]), net, false, customScripts);
+
+  const tx = new btc.Transaction({ customScripts });
+  tx.addInput({
+    ...revealPayment,
+    txid: utxo.txid,
+    index: utxo.vout,
+    witnessUtxo: {
+      script: preparedInscription.commitAddress.script,
+      amount: BigInt(utxo.value),
+    }
+  });
+
+  const inscSize = preparedInscription.inscription.body?.length || 0;
+  const estimatedVsize = 200 + Math.ceil(inscSize * 1.02);
+  const fee = BigInt(calculateFee(estimatedVsize, feeRate));
+
+  const outAddr = destinationAddress || preparedInscription.commitAddress.address;
+  tx.addOutputAddress(outAddr, POSTAGE_VALUE, net);
+  const change = BigInt(utxo.value) - fee - POSTAGE_VALUE;
+  if (change > 0 && utxo.script?.address) {
+    tx.addOutputAddress(utxo.script.address, change, net);
+  }
+
+  if (privateKey) {
+    tx.sign(privateKey);
+    tx.finalize();
+    const bytes = tx.extract();
+    return {
+      tx,
+      fee: Number(fee),
+      vsize: estimatedVsize,
+      hex: hex.encode(bytes),
+      base64: base64.encode(bytes),
+      transactionId: '',
+    };
+  }
+
+  const psbt = tx.toPSBT();
+  const psbt64 = typeof psbt === 'string' ? psbt : Buffer.from(psbt).toString('base64');
+  return {
+    tx,
+    fee: Number(fee),
+    vsize: estimatedVsize,
+    hex: psbt64,
+    base64: psbt64,
+    transactionId: '',
+  };
+}

--- a/packages/ordinalsplus/tests/unit/transactions/simple.test.ts
+++ b/packages/ordinalsplus/tests/unit/transactions/simple.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from 'bun:test';
+import { createSimpleCommitTransaction, createSimpleRevealTransaction } from '../../src/transactions/simple';
+import { createTextInscription } from '../../src/inscription';
+import type { Utxo } from '../../src/types';
+import * as btc from '@scure/btc-signer';
+
+const mockUtxo: Utxo = {
+  txid: 'a'.repeat(64),
+  vout: 0,
+  value: 10000,
+  scriptPubKey: '0014d85c2b71d0060b09c9886aeb815e50991dda124d',
+  script: { type: 'p2wpkh', address: 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx' }
+};
+
+describe('simple commit and reveal', () => {
+  test('createSimpleCommitTransaction returns psbt', async () => {
+    const inscription = createTextInscription('hi', 'testnet');
+    const result = await createSimpleCommitTransaction({
+      inscription,
+      utxo: mockUtxo,
+      changeAddress: 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
+      feeRate: 2,
+      network: 'testnet'
+    });
+    expect(result.commitAddress).toBe(inscription.commitAddress.address);
+    expect(result.commitPsbtBase64).toBeDefined();
+  });
+
+  test('createSimpleRevealTransaction returns tx', async () => {
+    const inscription = createTextInscription('hi', 'testnet');
+    const commitRes = await createSimpleCommitTransaction({
+      inscription,
+      utxo: mockUtxo,
+      changeAddress: 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
+      feeRate: 2,
+      network: 'testnet'
+    });
+    const revealUtxo: Utxo = {
+      txid: 'b'.repeat(64),
+      vout: 0,
+      value: 2000,
+      script: { type: 'p2tr', address: commitRes.commitAddress }
+    } as any;
+    const result = await createSimpleRevealTransaction({
+      utxo: revealUtxo,
+      preparedInscription: inscription,
+      feeRate: 2,
+      network: 'testnet',
+      privateKey: inscription.revealPrivateKey as Uint8Array
+    });
+    expect(result.tx).toBeInstanceOf(btc.Transaction);
+  });
+});


### PR DESCRIPTION
## Summary
- refactor TransactionStep.tsx to use `createSimpleCommitTransaction`
- use `createSimpleRevealTransaction` when building reveal step

## Testing
- `npm test` *(fails: vi.mock is not a function)*