### PR TITLE
Add runtime env validation

### DIFF
--- a/packages/ordinals-plus-api/src/config/apiConfig.ts
+++ b/packages/ordinals-plus-api/src/config/apiConfig.ts
@@ -3,11 +3,12 @@ import { cors } from '@elysiajs/cors';
 import { swagger } from '@elysiajs/swagger';
 import { InscriptionNotFoundError } from '../services/inscriptionService';
 import type { ErrorResponse } from '../types';
+import { env } from './envConfig';
 
 // Define API configuration
-export const PORT = process.env.PORT || 3001;
-export const HOST = process.env.HOST || '0.0.0.0';
-export const API_BASE_URL = process.env.API_BASE_URL || `http://localhost:${PORT}`;
+export const PORT = env.PORT;
+export const HOST = env.HOST ?? '0.0.0.0';
+export const API_BASE_URL = env.API_BASE_URL || `http://localhost:${PORT}`;
 
 // Constants for the API
 export const MIN_DUST = 546; // Sats

--- a/packages/ordinals-plus-api/src/config/envConfig.ts
+++ b/packages/ordinals-plus-api/src/config/envConfig.ts
@@ -1,0 +1,40 @@
+import * as v from 'valibot';
+
+// Schema for API environment variables
+const EnvSchema = v.object({
+  ORDISCAN_API_KEY: v.string(),
+  ORD_NODE_URL: v.string(),
+  PORT: v.number(),
+  HOST: v.optional(v.string()),
+  API_BASE_URL: v.optional(v.string()),
+  MAINNET_ORD_NODE_URL: v.optional(v.string()),
+  TESTNET_ORD_NODE_URL: v.optional(v.string()),
+  SIGNET_ORD_NODE_URL: v.optional(v.string()),
+  MAINNET_ORDISCAN_API_KEY: v.optional(v.string()),
+  TESTNET_ORDISCAN_API_KEY: v.optional(v.string()),
+});
+
+export type EnvConfig = v.InferOutput<typeof EnvSchema>;
+
+export function loadEnv(): EnvConfig {
+  try {
+    const raw = {
+      ORDISCAN_API_KEY: process.env.ORDISCAN_API_KEY,
+      ORD_NODE_URL: process.env.ORD_NODE_URL,
+      PORT: Number(process.env.PORT ?? '3001'),
+      HOST: process.env.HOST ?? '0.0.0.0',
+      API_BASE_URL: process.env.API_BASE_URL,
+      MAINNET_ORD_NODE_URL: process.env.MAINNET_ORD_NODE_URL,
+      TESTNET_ORD_NODE_URL: process.env.TESTNET_ORD_NODE_URL,
+      SIGNET_ORD_NODE_URL: process.env.SIGNET_ORD_NODE_URL,
+      MAINNET_ORDISCAN_API_KEY: process.env.MAINNET_ORDISCAN_API_KEY,
+      TESTNET_ORDISCAN_API_KEY: process.env.TESTNET_ORDISCAN_API_KEY,
+    };
+    return v.parse(EnvSchema, raw);
+  } catch (err) {
+    console.error('Invalid API environment configuration:', err);
+    process.exit(1);
+  }
+}
+
+export const env = loadEnv();

--- a/packages/ordinals-plus-api/src/config/vcApiConfig.ts
+++ b/packages/ordinals-plus-api/src/config/vcApiConfig.ts
@@ -42,9 +42,11 @@ export interface VCApiProviderConfig {
  * 
  * @returns Array of configured VC API providers
  */
+import { env } from './envConfig';
+
 export function getVCApiProviders(): VCApiProviderConfig[] {
   const providers: VCApiProviderConfig[] = [];
-  const defaultProviderId = process.env.VC_API_DEFAULT_PROVIDER || '1';
+  const defaultProviderId = env.VC_API_DEFAULT_PROVIDER || '1';
   
   // Find all provider configurations in environment variables
   for (let i = 1; i <= 10; i++) { // Support up to 10 providers
@@ -76,8 +78,8 @@ export function getVCApiProviders(): VCApiProviderConfig[] {
     providers.push({
       id: '1',
       name: 'Default VC API',
-      url: process.env.VC_API_URL || 'https://api.example.com/vc',
-      authToken: process.env.VC_API_AUTH_TOKEN || 'placeholder-token',
+      url: env.VC_API_URL || 'https://api.example.com/vc',
+      authToken: env.VC_API_AUTH_TOKEN || 'placeholder-token',
       isDefault: true
     });
   }
@@ -115,8 +117,8 @@ export function getDefaultVCApiProvider(): VCApiProviderConfig {
   return {
     id: 'fallback',
     name: 'Emergency Fallback Provider',
-    url: process.env.VC_API_URL || 'https://api.example.com/vc',
-    authToken: process.env.VC_API_AUTH_TOKEN || 'placeholder-token',
+    url: env.VC_API_URL || 'https://api.example.com/vc',
+    authToken: env.VC_API_AUTH_TOKEN || 'placeholder-token',
     isDefault: true
   };
 }

--- a/packages/ordinals-plus-api/src/controllers/exploreController.ts
+++ b/packages/ordinals-plus-api/src/controllers/exploreController.ts
@@ -2,6 +2,7 @@ import { fetchInscriptions } from '../services/ordinalsService';
 import { createDidFromInscription, isValidDid } from '../services/didService';
 import { processInscriptionsForLinkedResources } from '../services/linkedResourcesService';
 import type { ExplorerApiResponse, DID } from '../types';
+import { env } from '../config/envConfig';
 
 // Simple cache to avoid refetching on every request
 let cachedResponse: ExplorerApiResponse | null = null;
@@ -11,7 +12,7 @@ const CACHE_TTL = 5 * 60 * 1000; // 5 minutes cache
 export const exploreDidsOrd = async (page = 0, itemsPerPage = 50): Promise<ExplorerApiResponse> => {
   try {
     // Check if API key is set
-    if (!process.env.ORDISCAN_API_KEY) {
+    if (!env.ORDISCAN_API_KEY) {
       console.error('ORDISCAN_API_KEY is not set in environment variables.');
       return {
         dids: [],

--- a/packages/ordinals-plus-api/src/routers/verificationRouter.ts
+++ b/packages/ordinals-plus-api/src/routers/verificationRouter.ts
@@ -18,6 +18,7 @@ import type { CollectionInscriptionRepository } from '../types/collectionInscrip
 import { InMemoryCredentialRepository } from '../repositories/credentialRepository';
 import { InMemoryCollectionRepository } from '../repositories/collectionRepository';
 import { InMemoryCollectionInscriptionRepository } from '../repositories/collectionInscriptionRepository';
+import { env } from '../config/envConfig';
 
 // Create services
 const apiService = new ApiService();
@@ -112,7 +113,7 @@ async function verifyCredentialBasic(credential: any): Promise<{ valid: boolean;
  * Fetch inscription metadata using the Ordiscan API
  */
 async function fetchInscriptionMetadata(inscriptionId: string): Promise<any> {
-  const apiKey = process.env.ORDISCAN_API_KEY;
+  const apiKey = env.ORDISCAN_API_KEY;
   if (!apiKey) {
     throw new Error('Ordiscan API key not configured');
   }

--- a/packages/ordinals-plus-api/src/services/apiService.ts
+++ b/packages/ordinals-plus-api/src/services/apiService.ts
@@ -4,6 +4,7 @@
  * This service handles API requests to external services.
  */
 import { logger } from '../utils/logger';
+import { env } from '../config/envConfig';
 
 /**
  * Response from an API request
@@ -28,7 +29,7 @@ export class ApiService {
    * 
    * @param baseUrl - Base URL for API requests
    */
-  constructor(baseUrl: string = process.env.API_BASE_URL || 'https://api.ordinalsplus.com') {
+  constructor(baseUrl: string = env.API_BASE_URL || 'https://api.ordinalsplus.com') {
     this.baseUrl = baseUrl;
   }
 

--- a/packages/ordinals-plus-api/src/services/inscriptionService.ts
+++ b/packages/ordinals-plus-api/src/services/inscriptionService.ts
@@ -1,7 +1,8 @@
 import type { InscriptionDetailsResponse } from '../types';
+import { env } from '../config/envConfig';
 
 // Environment variable for Ord node URL (default to localhost:80 if not set)
-const ORD_NODE_URL = process.env.ORD_NODE_URL || 'http://127.0.0.1:80';
+const ORD_NODE_URL = env.ORD_NODE_URL || 'http://127.0.0.1:80';
 
 /**
  * Custom Error class for Inscription not found scenario.

--- a/packages/ordinals-plus-api/src/services/ordinalsService.ts
+++ b/packages/ordinals-plus-api/src/services/ordinalsService.ts
@@ -1,8 +1,9 @@
 import type { InscriptionResponse } from '../types';
 import type { Inscription } from 'ordinalsplus';
 import { OrdiscanProvider } from 'ordinalsplus';
+import { env } from '../config/envConfig';
 
-const ORDISCAN_API_KEY = process.env.ORDISCAN_API_KEY;
+const ORDISCAN_API_KEY = env.ORDISCAN_API_KEY;
 let provider: OrdiscanProvider;
 
 // Local options type definition might be slightly different from the actual one,

--- a/packages/ordinals-plus-api/src/services/providerService.ts
+++ b/packages/ordinals-plus-api/src/services/providerService.ts
@@ -1,4 +1,5 @@
 import { OrdiscanProvider, OrdNodeProvider, type BitcoinNetwork, type ResourceProvider } from 'ordinalsplus';
+import { env } from '../config/envConfig';
 
 // Cache for provider instances per network
 const providerCache: Partial<Record<string, ResourceProvider>> = {};
@@ -22,16 +23,16 @@ export function getProvider(network: string = 'mainnet'): ResourceProvider | nul
     // Determine configuration based on network
     switch (network) {
         case 'mainnet':
-            nodeUrl = process.env.MAINNET_ORD_NODE_URL;
-            ordiscanKey = process.env.MAINNET_ORDISCAN_API_KEY || process.env.ORDISCAN_API_KEY; // Allow global fallback
+            nodeUrl = env.MAINNET_ORD_NODE_URL;
+            ordiscanKey = env.MAINNET_ORDISCAN_API_KEY || env.ORDISCAN_API_KEY; // Allow global fallback
             break;
         case 'testnet':
-            nodeUrl = process.env.TESTNET_ORD_NODE_URL;
-            ordiscanKey = process.env.TESTNET_ORDISCAN_API_KEY; // No global fallback for testnet key
+            nodeUrl = env.TESTNET_ORD_NODE_URL;
+            ordiscanKey = env.TESTNET_ORDISCAN_API_KEY; // No global fallback for testnet key
             break;
         case 'signet':
             // Default Signet URL if env var is not set
-            nodeUrl = process.env.SIGNET_ORD_NODE_URL || 'http://127.0.0.1:80'; 
+            nodeUrl = env.SIGNET_ORD_NODE_URL || 'http://127.0.0.1:80';
             console.log(`[ProviderService] Signet nodeUrl resolved to: ${nodeUrl}`);
             // Ordiscan doesn't support Signet, use local ord node
             break;

--- a/packages/ordinals-plus-api/src/services/resourceInscriptionService.ts
+++ b/packages/ordinals-plus-api/src/services/resourceInscriptionService.ts
@@ -25,9 +25,10 @@ import { DEFAULT_VALIDATION_RULES, ResourceValidationRules } from '../validation
 import { DIDService, DID_REGEX } from './didService';
 import { VCService } from './vcService';
 import { logger } from '../utils/logger';
+import { env } from '../config/envConfig';
 
 // Environment variable for Ord node URL (default to localhost:80 if not set)
-const ORD_NODE_URL = process.env.ORD_NODE_URL || 'http://127.0.0.1:80';
+const ORD_NODE_URL = env.ORD_NODE_URL || 'http://127.0.0.1:80';
 
 /**
  * Custom Error class for Resource Inscription errors

--- a/packages/ordinals-plus-api/src/services/verificationService.ts
+++ b/packages/ordinals-plus-api/src/services/verificationService.ts
@@ -8,6 +8,7 @@ import { VerificationStatus, type VerificationResult, type IssuerInfo } from '..
 import { ApiService } from './apiService';
 import { logger } from '../utils/logger';
 import { BtcoDidResolver } from 'ordinalsplus';
+import { env } from '../config/envConfig';
 
 /**
  * Cache entry for verification results
@@ -278,7 +279,7 @@ export class VerificationService {
    * @returns Promise resolving to metadata
    */
   private async fetchInscriptionMetadata(inscriptionId: string): Promise<any> {
-    const apiKey = process.env.ORDISCAN_API_KEY;
+    const apiKey = env.ORDISCAN_API_KEY;
     if (!apiKey) {
       throw new Error('Ordiscan API key not configured');
     }

--- a/packages/ordinals-plus-explorer/src/config/envConfig.ts
+++ b/packages/ordinals-plus-explorer/src/config/envConfig.ts
@@ -1,0 +1,26 @@
+import * as v from 'valibot';
+
+// Schema for frontend environment variables
+const EnvSchema = v.object({
+  VITE_BACKEND_URL: v.string(),
+  VITE_DEFAULT_NETWORK: v.string(),
+  VITE_API_BASE_URL: v.optional(v.string())
+});
+
+export type EnvConfig = v.InferOutput<typeof EnvSchema>;
+
+export function loadEnv(): EnvConfig {
+  try {
+    const values = {
+      VITE_BACKEND_URL: import.meta.env.VITE_BACKEND_URL,
+      VITE_DEFAULT_NETWORK: import.meta.env.VITE_DEFAULT_NETWORK,
+      VITE_API_BASE_URL: import.meta.env.VITE_API_BASE_URL,
+    };
+    return v.parse(EnvSchema, values);
+  } catch (err) {
+    console.error('Invalid frontend environment configuration:', err);
+    throw err;
+  }
+}
+
+export const env = loadEnv();

--- a/packages/ordinals-plus-explorer/src/context/ApiContext.tsx
+++ b/packages/ordinals-plus-explorer/src/context/ApiContext.tsx
@@ -2,6 +2,7 @@
 import React, { createContext, useContext, ReactNode, useMemo } from 'react';
 import ApiService from '../services/apiService';
 import { useNetwork } from './NetworkContext'; // Import useNetwork
+import { env } from '../config/envConfig';
 
 // Define the shape of the context data
 interface ApiContextType {
@@ -20,7 +21,7 @@ interface ApiProviderProps {
 export const ApiProvider: React.FC<ApiProviderProps> = ({ children }) => {
   // Get the *initial* API base URL from environment variables
   // This will be used if no network context is found or if the network doesn't provide an apiUrl
-  const initialApiUrl = import.meta.env.VITE_API_BASE_URL || 
+  const initialApiUrl = env.VITE_API_BASE_URL ||
                         (window.Cypress ? Cypress.env('API_BASE_URL') : undefined);
 
   // Use the NetworkContext to get the active network

--- a/packages/ordinals-plus-explorer/src/env.d.ts
+++ b/packages/ordinals-plus-explorer/src/env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_BACKEND_URL: string;
   readonly VITE_DEFAULT_NETWORK: string;
+  readonly VITE_API_BASE_URL: string;
 }
 
 interface ImportMeta {

--- a/packages/ordinals-plus-explorer/src/hooks/useApiService.ts
+++ b/packages/ordinals-plus-explorer/src/hooks/useApiService.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import ApiServiceProvider, { ApiProviderType } from '../services/ApiServiceProvider';
+import { env } from '../config/envConfig';
 
 /**
  * Custom hook that provides access to the API service provider
@@ -14,7 +15,7 @@ export const useApiService = () => {
     const provider = ApiServiceProvider.getInstance();
     
     // Get backend URL from environment with fallback
-    const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000';
+    const backendUrl = env.VITE_BACKEND_URL || 'http://localhost:3000';
     
     // Configure the API service with the backend URL
     provider.updateConfig({

--- a/packages/ordinals-plus-explorer/src/hooks/useUserDids.ts
+++ b/packages/ordinals-plus-explorer/src/hooks/useUserDids.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import fetchClient from '../utils/fetchUtils';
+import { env } from '../config/envConfig';
 
 /**
  * Hook for retrieving user DIDs
@@ -17,7 +18,7 @@ export const useUserDids = () => {
       
       try {
         // Get the API base URL from environment
-        const apiBaseUrl = process.env.REACT_APP_API_URL || 'http://localhost:3001/api';
+        const apiBaseUrl = env.VITE_BACKEND_URL || 'http://localhost:3001/api';
         
         // Get auth token from local storage
         const token = localStorage.getItem('authToken');

--- a/packages/ordinals-plus-explorer/src/main.tsx
+++ b/packages/ordinals-plus-explorer/src/main.tsx
@@ -5,9 +5,10 @@ import './index.css'; // Assuming Tailwind CSS setup is here
 import { ApiProvider } from './context/ApiContext';
 import { NetworkProvider } from './context/NetworkContext';
 import { WalletProvider } from './context/WalletContext'; // Our direct wallet provider
+import { env } from './config/envConfig';
 
 // Add debug logging for initialization
-console.log('Initializing application with direct wallet support');
+console.log('Initializing application with direct wallet support', env);
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/packages/ordinals-plus-explorer/src/services/ApiServiceProvider.ts
+++ b/packages/ordinals-plus-explorer/src/services/ApiServiceProvider.ts
@@ -1,6 +1,7 @@
 import ApiService from './apiService';
 import { ApiServiceConfig } from './types';
 import { NetworkInfo } from '../context/NetworkContext'; // Import NetworkInfo type
+import { env } from '../config/envConfig';
 
 // Define the API Provider types
 export enum ApiProviderType {
@@ -48,7 +49,7 @@ class ApiServiceProvider {
     // Default configuration - adjust as needed
     this.config = {
         type: ApiProviderType.ORDISCAN, // Default to Ordiscan or determine dynamically
-        baseUrl: import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000', // Default URL
+        baseUrl: env.VITE_BACKEND_URL || 'http://localhost:3000', // Default URL
         timeout: 10000 // Increased timeout slightly
     };
     console.log('[ApiServiceProvider] Initialized with config:', this.config);

--- a/packages/ordinals-plus-explorer/src/services/apiClient.ts
+++ b/packages/ordinals-plus-explorer/src/services/apiClient.ts
@@ -1,9 +1,10 @@
 import { createFetchClient } from '../utils/fetchUtils';
 import type { FetchRequestConfig, FetchResponse } from '../utils/fetchUtils';
+import { env } from '../config/envConfig';
 
 // Create a fetch client instance with default configuration
 const baseApiClient = createFetchClient({
-  baseURL: process.env.REACT_APP_API_URL || 'http://localhost:3001/api',
+  baseURL: env.VITE_BACKEND_URL || 'http://localhost:3001/api',
   headers: {
     'Content-Type': 'application/json',
   },

--- a/packages/ordinals-plus-explorer/src/services/collectionService.ts
+++ b/packages/ordinals-plus-explorer/src/services/collectionService.ts
@@ -1,4 +1,5 @@
 import fetchClient from '../utils/fetchUtils';
+import { env } from '../config/envConfig';
 
 // Collection types
 export enum CollectionVisibility {
@@ -62,7 +63,7 @@ export interface CreateCollectionParams {
 }
 
 // API client setup
-const apiBaseUrl = process.env.REACT_APP_API_URL || 'http://localhost:3001/api';
+const apiBaseUrl = env.VITE_BACKEND_URL || 'http://localhost:3001/api';
 
 const getAuthHeaders = (): Record<string, string> => {
   const token = localStorage.getItem('authToken');


### PR DESCRIPTION
## Summary
- validate API env vars with `valibot`
- wire API code to use validated config
- add frontend env loader and use it across explorer

## Testing
- `npm test` *(fails: 52 failing tests)*

------
https://chatgpt.com/codex/tasks/task_b_6853b5e06d848321bf142ce8f9399436