### PR TITLE
Add pluggable storage backend for MemoryIndexerDatabase

### DIFF
--- a/packages/ordinalsplus/src/db/storage-backend.ts
+++ b/packages/ordinalsplus/src/db/storage-backend.ts
@@ -1,0 +1,25 @@
+export interface StorageBackend {
+  get<T>(key: string): Promise<T | null>;
+  set<T>(key: string, value: T | null): Promise<void>;
+  clear(): Promise<void>;
+}
+
+export class InMemoryBackend implements StorageBackend {
+  private store = new Map<string, any>();
+
+  async get<T>(key: string): Promise<T | null> {
+    return this.store.has(key) ? (this.store.get(key) as T) : null;
+  }
+
+  async set<T>(key: string, value: T | null): Promise<void> {
+    if (value === null) {
+      this.store.delete(key);
+      return;
+    }
+    this.store.set(key, value);
+  }
+
+  async clear(): Promise<void> {
+    this.store.clear();
+  }
+}

--- a/packages/ordinalsplus/src/index.ts
+++ b/packages/ordinalsplus/src/index.ts
@@ -123,7 +123,9 @@ export {
 // --- Indexer Exports ---
 export {
   OrdinalsIndexer,
-  MemoryIndexerDatabase
+  MemoryIndexerDatabase,
+  StorageBackend,
+  InMemoryBackend
 } from './indexer';
 
 export {

--- a/packages/ordinalsplus/src/indexer/index.ts
+++ b/packages/ordinalsplus/src/indexer/index.ts
@@ -5,6 +5,7 @@
 
 export * from './ordinals-indexer';
 export * from './memory-db';
+export * from '../db/storage-backend';
 export * from './logger';
 export * from './errors';
 export * from './error-handling';

--- a/packages/ordinalsplus/src/indexer/memory-db.ts
+++ b/packages/ordinalsplus/src/indexer/memory-db.ts
@@ -3,6 +3,7 @@
  */
 
 import { IndexerDatabase, IndexerInscription } from '../types';
+import { StorageBackend, InMemoryBackend } from '../db/storage-backend';
 
 /**
  * MemoryIndexerDatabase provides a simple in-memory implementation of IndexerDatabase
@@ -11,35 +12,57 @@ import { IndexerDatabase, IndexerInscription } from '../types';
  * Production applications should implement a persistent database solution.
  */
 export class MemoryIndexerDatabase implements IndexerDatabase {
-  private inscriptions: Map<string, IndexerInscription> = new Map();
-  private contents: Map<string, Buffer> = new Map();
-  private metadata: Map<string, any> = new Map();
-  private satoshipIndexes: Map<string, string[]> = new Map();
-  private didDocuments: Map<string, any> = new Map();
-  private credentials: Map<string, any> = new Map();
-  private lastSyncedHeight: number = 0;
+  private backend: StorageBackend;
+  private ttlMs: number | null;
+
+  constructor(options: { backend?: StorageBackend; ttlMs?: number } = {}) {
+    this.backend = options.backend ?? new InMemoryBackend();
+    this.ttlMs = options.ttlMs ?? null;
+  }
+
+  private makeKey(type: string, id: string): string {
+    return `${type}:${id}`;
+  }
+
+  private async getEntry<T>(key: string): Promise<T | null> {
+    const entry = await this.backend.get<{ data: T; expiresAt: number | null }>(key);
+    if (!entry) return null;
+    if (entry.expiresAt && Date.now() > entry.expiresAt) {
+      await this.backend.set(key, null);
+      return null;
+    }
+    return entry.data;
+  }
+
+  private async setEntry<T>(key: string, data: T): Promise<void> {
+    const expiresAt = this.ttlMs ? Date.now() + this.ttlMs : null;
+    await this.backend.set(key, { data, expiresAt });
+  }
   
   /**
    * Get an inscription by its ID
    */
   async getInscription(id: string): Promise<IndexerInscription | null> {
-    return this.inscriptions.get(id) || null;
+    return this.getEntry<IndexerInscription>(this.makeKey('inscription', id));
   }
   
   /**
    * Store an inscription
    */
   async storeInscription(inscription: IndexerInscription): Promise<void> {
-    this.inscriptions.set(inscription.id, inscription);
-    
-    // Update satoshi index
-    const satoshi = inscription.satoshi;
-    if (satoshi) {
-      const ids = this.satoshipIndexes.get(satoshi) || [];
-      if (!ids.includes(inscription.id)) {
-        ids.push(inscription.id);
-        this.satoshipIndexes.set(satoshi, ids);
-      }
+    await this.setEntry(this.makeKey('inscription', inscription.id), inscription);
+
+    const satKey = this.makeKey('satoshi', inscription.satoshi);
+    const ids = (await this.getEntry<string[]>(satKey)) || [];
+    if (!ids.includes(inscription.id)) {
+      ids.push(inscription.id);
+      await this.setEntry(satKey, ids);
+    }
+
+    const allIds = (await this.getEntry<string[]>(this.makeKey('all', 'ids'))) || [];
+    if (!allIds.includes(inscription.id)) {
+      allIds.push(inscription.id);
+      await this.setEntry(this.makeKey('all', 'ids'), allIds);
     }
   }
   
@@ -47,99 +70,104 @@ export class MemoryIndexerDatabase implements IndexerDatabase {
    * Get inscriptions associated with a satoshi
    */
   async getInscriptionsBySatoshi(satoshi: string): Promise<IndexerInscription[]> {
-    const ids = this.satoshipIndexes.get(satoshi) || [];
-    return ids
-      .map(id => this.inscriptions.get(id))
-      .filter(Boolean) as IndexerInscription[];
+    const ids = (await this.getEntry<string[]>(this.makeKey('satoshi', satoshi))) || [];
+    const results: IndexerInscription[] = [];
+    for (const id of ids) {
+      const ins = await this.getInscription(id);
+      if (ins) results.push(ins);
+    }
+    return results;
   }
   
   /**
    * Get raw inscription content
    */
   async getInscriptionContent(id: string): Promise<Buffer | null> {
-    return this.contents.get(id) || null;
+    return this.getEntry<Buffer>(this.makeKey('content', id));
   }
   
   /**
    * Store raw inscription content
    */
   async storeInscriptionContent(id: string, content: Buffer): Promise<void> {
-    this.contents.set(id, content);
+    await this.setEntry(this.makeKey('content', id), content);
   }
   
   /**
    * Get decoded metadata for an inscription
    */
   async getInscriptionMetadata(id: string): Promise<any | null> {
-    return this.metadata.get(id) || null;
+    return this.getEntry<any>(this.makeKey('metadata', id));
   }
   
   /**
    * Store decoded metadata for an inscription
    */
   async storeInscriptionMetadata(id: string, metadata: any): Promise<void> {
-    this.metadata.set(id, metadata);
+    await this.setEntry(this.makeKey('metadata', id), metadata);
   }
   
   /**
    * Get the last synced block height
    */
   async getLastSyncedHeight(): Promise<number | null> {
-    return this.lastSyncedHeight;
+    return this.getEntry<number>('lastSyncedHeight');
   }
   
   /**
    * Update the last synced block height
    */
   async setLastSyncedHeight(height: number): Promise<void> {
-    this.lastSyncedHeight = height;
+    await this.setEntry('lastSyncedHeight', height);
   }
   
   /**
    * Store a DID document
    */
   async storeDIDDocument(didId: string, document: any): Promise<void> {
-    this.didDocuments.set(didId, document);
+    await this.setEntry(this.makeKey('did', didId), document);
   }
   
   /**
    * Store a verifiable credential
    */
   async storeCredential(inscriptionId: string, credential: any): Promise<void> {
-    this.credentials.set(inscriptionId, credential);
+    await this.setEntry(this.makeKey('credential', inscriptionId), credential);
   }
   
   /**
    * Get all stored inscriptions (for testing)
    */
   async getAllInscriptions(): Promise<IndexerInscription[]> {
-    return Array.from(this.inscriptions.values());
+    // naive implementation: rely on satoshi index
+    const idsEntry = await this.backend.get<string[]>(this.makeKey('all', 'ids'));
+    const ids = idsEntry || [];
+    const res: IndexerInscription[] = [];
+    for (const id of ids) {
+      const ins = await this.getInscription(id);
+      if (ins) res.push(ins);
+    }
+    return res;
   }
   
   /**
    * Get a DID document by ID (for testing)
    */
   async getDIDDocument(didId: string): Promise<any | null> {
-    return this.didDocuments.get(didId) || null;
+    return this.getEntry<any>(this.makeKey('did', didId));
   }
   
   /**
    * Get a credential by inscription ID (for testing)
    */
   async getCredential(inscriptionId: string): Promise<any | null> {
-    return this.credentials.get(inscriptionId) || null;
+    return this.getEntry<any>(this.makeKey('credential', inscriptionId));
   }
   
   /**
    * Clear all stored data (for testing)
    */
   async clearAll(): Promise<void> {
-    this.inscriptions.clear();
-    this.contents.clear();
-    this.metadata.clear();
-    this.satoshipIndexes.clear();
-    this.didDocuments.clear();
-    this.credentials.clear();
-    this.lastSyncedHeight = 0;
+    await this.backend.clear();
   }
-} 
+}


### PR DESCRIPTION
## Summary
- implement `StorageBackend` interface with a default `InMemoryBackend`
- refactor `MemoryIndexerDatabase` to use `StorageBackend` for persistence
- export backend helpers from indexer module

## Testing
- `./scripts/configure.sh` *(fails: GET https://registry.npmjs.org/... 403)*
- `npm test` *(fails: 52 tests failed)*

------
https://chatgpt.com/codex/tasks/task_b_6853b5ec51b88321aac93bdd1c4530b4